### PR TITLE
bump bundle version to v0.1.4

### DIFF
--- a/config/olm/reference-addon.csv.tpl.yaml
+++ b/config/olm/reference-addon.csv.tpl.yaml
@@ -6,7 +6,7 @@ metadata:
     support: "false"
     containerImage: +MANAGER_IMAGE_TO_REPLACE+
     capabilities: Full Lifecycle
-  name: reference-addon.v0.1.0
+  name: reference-addon.v0.1.4
 spec:
   description: |-
     Reference Addon is a real Addon, created to validate and demonstrate the Addons Flow.
@@ -26,7 +26,7 @@ spec:
   links:
   - name: Source Code
     url: https://github.com/openshift/reference-addon
-  version: 0.1.0
+  version: 0.1.4
   cleanup:
     enabled: false
   installModes:


### PR DESCRIPTION
We currently don't know where the release tags in this repo and in the openshift/addon-operator repo come from.

We're suspecting either a configuration flag in openshift/release that defaults to 0.1.0 or csv-parsing magic that infers the version from a csv that is part of a PR.
Could be something totally different though as well.

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>