### PR TITLE
feat: add parameterGetter

### DIFF
--- a/cmd/reference-addon-manager/main.go
+++ b/cmd/reference-addon-manager/main.go
@@ -36,9 +36,10 @@ func init() {
 }
 
 const (
-	addonNamespace = "redhat-reference-addon"
-	operatorName   = "reference-addon"
-	deleteLabel    = "api.openshift.com/addon-reference-addon-delete"
+	addonNamespace           = "redhat-reference-addon"
+	operatorName             = "reference-addon"
+	deleteLabel              = "api.openshift.com/addon-reference-addon-delete"
+	addonParameterSecretname = "addon-reference-addon-parameters"
 )
 
 func main() {
@@ -121,11 +122,20 @@ func main() {
 		setupLog.Error(fmt.Errorf("unable to set up ready check: %w", err), "setting up manager")
 		os.Exit(1)
 	}
+
+	client := mgr.GetClient()
+
 	// the following section hooks up a heartbeat reporter with the current addon/operator
 	r, err := controllers.NewReferenceAddonReconciler(
-		mgr.GetClient(),
+		client,
+		controllers.NewSecretParameterGetter(
+			client,
+			controllers.WithNamespace(addonNamespace),
+			controllers.WithName(addonParameterSecretname),
+		),
 		controllers.WithLog{Log: ctrl.Log.WithName("controllers").WithName("ReferenceAddon")},
 		controllers.WithAddonNamespace(addonNamespace),
+		controllers.WithAddonParameterSecretName(addonParameterSecretname),
 		controllers.WithOperatorName(operatorName),
 		controllers.WithDeleteLabel(deleteLabel),
 	)

--- a/internal/controllers/options.go
+++ b/internal/controllers/options.go
@@ -34,6 +34,12 @@ func (w WithAddonNamespace) ConfigurePhaseUninstall(c *PhaseUninstallConfig) {
 	c.AddonNamespace = string(w)
 }
 
+type WithAddonParameterSecretName string
+
+func (w WithAddonParameterSecretName) ConfigureReferenceAddonReconciler(c *ReferenceAddonReconcilerConfig) {
+	c.AddonParameterSecretname = string(w)
+}
+
 type WithOperatorName string
 
 func (w WithOperatorName) ConfigureConfigMapUninstallSignaler(c *ConfigMapUninstallSignalerConfig) {
@@ -58,7 +64,17 @@ func (w WithDeleteLabel) ConfigureReferenceAddonReconciler(c *ReferenceAddonReco
 	c.DeleteLabel = string(w)
 }
 
+type WithName string
+
+func (w WithName) ConfigureSecretParameterGetter(c *SecretParameterGetterConfig) {
+	c.Name = string(w)
+}
+
 type WithNamespace string
+
+func (w WithNamespace) ConfigureSecretParameterGetter(c *SecretParameterGetterConfig) {
+	c.Namespace = string(w)
+}
 
 func (w WithNamespace) ConfigureListCSVs(c *ListCSVsConfig) {
 	c.Namespace = string(w)

--- a/internal/controllers/parameter_getter.go
+++ b/internal/controllers/parameter_getter.go
@@ -1,0 +1,75 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/reference-addon/internal/controllers/phase"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ParameterGetter interface {
+	GetParameters(ctx context.Context) (phase.RequestParameters, error)
+}
+
+func NewSecretParameterGetter(client client.Client, opts ...SecretParameteterGetterOption) *SecretParameterGetter {
+	var cfg SecretParameterGetterConfig
+
+	cfg.Option(opts...)
+
+	return &SecretParameterGetter{
+		cfg: cfg,
+
+		client: client,
+	}
+}
+
+type SecretParameterGetter struct {
+	cfg SecretParameterGetterConfig
+
+	client client.Client
+}
+
+const (
+	sizeParameterID = "size"
+)
+
+func (s *SecretParameterGetter) GetParameters(ctx context.Context) (phase.RequestParameters, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	key := client.ObjectKey{
+		Namespace: s.cfg.Namespace,
+		Name:      s.cfg.Name,
+	}
+
+	var params phase.RequestParameters
+
+	var secret corev1.Secret
+
+	if err := s.client.Get(ctx, key, &secret); err != nil {
+		return params, fmt.Errorf("retrieving addon parameters secret: %w", err)
+	}
+
+	if val, ok := secret.Data[sizeParameterID]; ok {
+		params.Size = string(val)
+	}
+
+	return params, nil
+}
+
+type SecretParameterGetterConfig struct {
+	Namespace string
+	Name      string
+}
+
+func (c *SecretParameterGetterConfig) Option(opts ...SecretParameteterGetterOption) {
+	for _, opt := range opts {
+		opt.ConfigureSecretParameterGetter(c)
+	}
+}
+
+type SecretParameteterGetterOption interface {
+	ConfigureSecretParameterGetter(*SecretParameterGetterConfig)
+}

--- a/internal/controllers/parameter_getter_test.go
+++ b/internal/controllers/parameter_getter_test.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift/reference-addon/internal/controllers/phase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSecretParameterGetterInterfaces(t *testing.T) {
+	t.Parallel()
+
+	require.Implements(t, new(ParameterGetter), new(SecretParameterGetter))
+}
+
+func TestSecretParameterGetter(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		ActualSecret   *corev1.Secret
+		Namespace      string
+		Name           string
+		ExpectedParams phase.RequestParameters
+	}{
+		"happy path": {
+			ActualSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-namespace",
+				},
+				Data: map[string][]byte{
+					"size": []byte("1"),
+				},
+			},
+			Namespace: "test-namespace",
+			Name:      "test",
+			ExpectedParams: phase.RequestParameters{
+				Size: "1",
+			},
+		},
+	} {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client := fake.
+				NewClientBuilder().
+				WithObjects(tc.ActualSecret).
+				Build()
+
+			getter := NewSecretParameterGetter(
+				client,
+				WithNamespace(tc.Namespace),
+				WithName(tc.Name),
+			)
+
+			params, err := getter.GetParameters(context.Background())
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.ExpectedParams, params)
+		})
+	}
+}

--- a/internal/controllers/phase/phase.go
+++ b/internal/controllers/phase/phase.go
@@ -12,6 +12,11 @@ type Phase interface {
 
 type Request struct {
 	Object types.NamespacedName
+	Params RequestParameters
+}
+
+type RequestParameters struct {
+	Size string
 }
 
 func Success() Result {

--- a/internal/controllers/phase_simulate_reconciliation.go
+++ b/internal/controllers/phase_simulate_reconciliation.go
@@ -26,6 +26,11 @@ type PhaseSimulateReconciliation struct {
 func (p *PhaseSimulateReconciliation) Execute(ctx context.Context, req phase.Request) phase.Result {
 	log := p.cfg.Log.WithValues("addon", req.Object.String())
 
+	log.Info(
+		"reconciling with addon parameters",
+		"Size", req.Params.Size,
+	)
+
 	// dummy code to indicate reconciliation of the reference-addon object
 	if strings.HasPrefix(req.Object.Name, "redhat-") {
 		log.Info("reconciling for a reference addon object prefixed by redhat- ")

--- a/internal/controllers/reference_addon_controller.go
+++ b/internal/controllers/reference_addon_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -15,10 +16,11 @@ import (
 	refapisv1alpha1 "github.com/openshift/reference-addon/apis/reference/v1alpha1"
 	"github.com/openshift/reference-addon/internal/controllers/phase"
 	"github.com/openshift/reference-addon/internal/metrics"
+	opsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func NewReferenceAddonReconciler(client client.Client, syncer ParameterGetter, opts ...ReferenceAddonReconcilerOption) (*ReferenceAddonReconciler, error) {
+func NewReferenceAddonReconciler(client client.Client, getter ParameterGetter, opts ...ReferenceAddonReconcilerOption) (*ReferenceAddonReconciler, error) {
 	var cfg ReferenceAddonReconcilerConfig
 
 	cfg.Option(opts...)
@@ -37,8 +39,8 @@ func NewReferenceAddonReconciler(client client.Client, syncer ParameterGetter, o
 	phaseUninstallLog := cfg.Log.WithName("phase").WithName("uninstall")
 
 	return &ReferenceAddonReconciler{
-		cfg:    cfg,
-		syncer: syncer,
+		cfg:         cfg,
+		paramGetter: getter,
 		orderedPhases: []phase.Phase{
 			NewPhaseUninstall(
 				signaler,
@@ -65,13 +67,13 @@ func NewReferenceAddonReconciler(client client.Client, syncer ParameterGetter, o
 type ReferenceAddonReconciler struct {
 	cfg ReferenceAddonReconcilerConfig
 
-	syncer ParameterGetter
+	paramGetter ParameterGetter
 
 	orderedPhases []phase.Phase
 }
 
 func (r *ReferenceAddonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	params, err := r.syncer.GetParameters(ctx)
+	params, err := r.paramGetter.GetParameters(ctx)
 	if err != nil {
 		// Log error and continue reconcilliation so subsequent phases
 		// can fail if required parameters are missing.
@@ -97,31 +99,40 @@ func (r *ReferenceAddonReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func (r *ReferenceAddonReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	configMapPredicates := predicate.NewPredicateFuncs(
-		func(obj client.Object) bool {
-			return obj.GetName() == r.cfg.OperatorName
-		},
-	)
-
-	secretPredicates := predicate.NewPredicateFuncs(
-		func(obj client.Object) bool {
-			return obj.GetName() == r.cfg.AddonParameterSecretname
-		},
-	)
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&refapisv1alpha1.ReferenceAddon{}).
 		Watches(
+			&source.Kind{Type: &opsv1alpha1.ClusterServiceVersion{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(hasNamePrefix(r.cfg.OperatorName)),
+		).
+		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(configMapPredicates),
+			builder.WithPredicates(hasName(r.cfg.OperatorName)),
 		).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(secretPredicates),
+			builder.WithPredicates(hasName(r.cfg.AddonParameterSecretname)),
 		).
 		Complete(r)
+}
+
+func hasNamePrefix(pfx string) predicate.Funcs {
+	return predicate.NewPredicateFuncs(
+		func(obj client.Object) bool {
+			return strings.HasPrefix(obj.GetName(), pfx)
+		},
+	)
+}
+
+func hasName(name string) predicate.Funcs {
+	return predicate.NewPredicateFuncs(
+		func(obj client.Object) bool {
+			return obj.GetName() == name
+		},
+	)
 }
 
 type ReferenceAddonReconcilerConfig struct {


### PR DESCRIPTION
### Summary

Adds the ability for the reference addon to retrieve addon parameters and keep them in sync with the addon parameters secret.

Also adds watched events for CSV's related to the addon's operator to ensure CSV deletion once the uninstall phase is triggered.