### PR TITLE
ci: add repo based imagestream definition

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.17


### PR DESCRIPTION
### Summary

Makes it possible to define imagestreams directly within this repository.